### PR TITLE
Backport support for mount-buildkite-agent

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -66,6 +66,8 @@ configuration:
       type: boolean
     workdir:
       type: string
+    mount-buildkite-agent:
+      type: boolean
   oneOf:
     - required:
       - run
@@ -92,3 +94,4 @@ configuration:
     tty: [ run ]
     workdir: [ run ]
     user: [ run ]
+    mount-buildkite-agent: [ run ]


### PR DESCRIPTION
Backport mount-buildkite-agent into v3 so it can be used without moving the whole branch forward.

--

(copied from docker-buildkite-plugin)

cherry-pick 1c01b5c859085d2b3e5ac9f37ed6a03bc5210ebe